### PR TITLE
Fix missing dependency that was find_packaged

### DIFF
--- a/off_highway_can/package.xml
+++ b/off_highway_can/package.xml
@@ -19,10 +19,11 @@
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/off_highway_can/package.xml
+++ b/off_highway_can/package.xml
@@ -16,14 +16,9 @@
   <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
 
-  <test_depend>ament_cmake_copyright</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
-  <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
It's `find_package`d here: https://github.com/bosch-engineering/off_highway_sensor_drivers/blob/humble-devel/off_highway_can/CMakeLists.txt#L60