### PR TITLE
Do not force warnings as errors to fix rolling

### DIFF
--- a/off_highway_can/CMakeLists.txt
+++ b/off_highway_can/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wdeprecated)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/off_highway_premium_radar_sample/CMakeLists.txt
+++ b/off_highway_premium_radar_sample/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Werror -Wdeprecated)
+  add_compile_options(-Wall -Wextra -Wdeprecated)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/off_highway_premium_radar_sample_msgs/CMakeLists.txt
+++ b/off_highway_premium_radar_sample_msgs/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wdeprecated)
 endif()
 
 # Dependencies

--- a/off_highway_radar/CMakeLists.txt
+++ b/off_highway_radar/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wdeprecated)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/off_highway_radar_msgs/CMakeLists.txt
+++ b/off_highway_radar_msgs/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wdeprecated)
 endif()
 
 # find dependencies

--- a/off_highway_uss/CMakeLists.txt
+++ b/off_highway_uss/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wdeprecated)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Warnings are warnings for a reason, otherwise they would have been errors :slightly_smiling_face: 

By not enforcing this, the code works on ros2 rolling as well.

If developers prefer failed compilations, they can still configure their colcon config to fail on warnings.