### PR TITLE
`rosidl_default_generators` is technically a `<buildtool_depend>`

### DIFF
--- a/off_highway_general_purpose_radar_msgs/package.xml
+++ b/off_highway_general_purpose_radar_msgs/package.xml
@@ -10,10 +10,10 @@
   <author email="robin.petereit@de.bosch.com">Robin Petereit</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>std_msgs</depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/off_highway_premium_radar_sample_msgs/package.xml
+++ b/off_highway_premium_radar_sample_msgs/package.xml
@@ -10,12 +10,12 @@
   <author email="robin.petereit@de.bosch.com">Robin Petereit</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/off_highway_radar_msgs/package.xml
+++ b/off_highway_radar_msgs/package.xml
@@ -11,11 +11,11 @@
   <author email="marcus.huenerbein@digital-workbench.de">Marcus Huenerbein</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/off_highway_uss_msgs/package.xml
+++ b/off_highway_uss_msgs/package.xml
@@ -11,11 +11,11 @@
   <author email="marcus.huenerbein@digital-workbench.de">Marcus Huenerbein</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
It's just a nitpick. But we're working on minimizing the dependencies of our software stack.