### PR TITLE
Compatible pcl_ros version 

### DIFF
--- a/off_highway_sensor_drivers_examples/README.md
+++ b/off_highway_sensor_drivers_examples/README.md
@@ -22,6 +22,7 @@ of your workspace and execute
 
 ```bash
 git clone -b ros2 https://github.com/ros-perception/perception_pcl
+git checkout c1ccdd2776043ba1477926acceab7df75f64bf22
 cd ..
 rosdep update && rosdep install --from-paths src --ignore-src -r -y
 colcon build --cmake-args '-DCMAKE_BUILD_TYPE=Release'


### PR DESCRIPTION
Actual branch `ros2` of perception_pcl (in particular `pcl_ros`) is not compatible with `off_highway_sensor_drivers_examples`: filters won't work.

You should add the checkout in README to the actual branch revision that works with this example.