### PR TITLE
tf2 uses hpp headers in rolling (and is backported)

### DIFF
--- a/off_highway_premium_radar_sample/src/converters/ros_message_conversions.hpp
+++ b/off_highway_premium_radar_sample/src/converters/ros_message_conversions.hpp
@@ -24,7 +24,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Quaternion.hpp"
 
 #include "off_highway_premium_radar_sample/pdu_definitions.hpp"
 


### PR DESCRIPTION
This change works on `humble`, `jazzy`, `kilted` and `rolling`.