### PR TITLE
Fix issue 20, don't publish sensor data when there is a sensor timeout

### DIFF
--- a/off_highway_can/include/off_highway_can/receiver.hpp
+++ b/off_highway_can/include/off_highway_can/receiver.hpp
@@ -155,7 +155,7 @@ private:
    *
    * \param stat Status wrapper of diagnostics.
    */
-  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat) const;
 
   /**
    * \brief Declare and get node parameters.

--- a/off_highway_can/include/off_highway_can/receiver.hpp
+++ b/off_highway_can/include/off_highway_can/receiver.hpp
@@ -141,6 +141,8 @@ protected:
   const bool use_fd_{false};
   /// Use J1939 protocol, defaults to false if J1939 protocol handling is not implemented for sensor
   bool use_j1939_{false};
+  /// Store the timeout status
+  bool is_timeout_{false};
 
 private:
   /**
@@ -153,7 +155,7 @@ private:
    *
    * \param stat Status wrapper of diagnostics.
    */
-  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat) const;
+  void diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   /**
    * \brief Declare and get node parameters.
@@ -174,7 +176,6 @@ private:
   /// CAN message storage, maps CAN id to message data including signals and their en-/decoding
   /// information
   Messages messages_;
-
 
   double timeout_;
   double watchdog_frequency_;

--- a/off_highway_can/src/receiver.cpp
+++ b/off_highway_can/src/receiver.cpp
@@ -106,15 +106,15 @@ void Receiver::force_diag_update()
   diag_updater_->force_update();
 }
 
-void Receiver::diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat) const
+void Receiver::diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
 
-  bool timeout = (now() - last_message_received_).seconds() > timeout_;
+  is_timeout_ = (now() - last_message_received_).seconds() > timeout_;
 
-  stat.add("Timeout", timeout);
+  stat.add("Timeout", is_timeout_);
 
-  if (timeout) {
+  if (is_timeout_) {
     stat.summary(DiagnosticStatus::ERROR, "Error");
   } else {
     stat.summary(DiagnosticStatus::OK, "Ok");

--- a/off_highway_can/src/receiver.cpp
+++ b/off_highway_can/src/receiver.cpp
@@ -79,7 +79,8 @@ void Receiver::stop()
 
 void Receiver::callback_watchdog()
 {
-  if ((now() - last_message_received_).seconds() > timeout_) {
+  is_timeout_ = (now() - last_message_received_).seconds() > timeout_;
+  if (is_timeout_) {
     RCLCPP_WARN(get_logger(), "Timeout of watchdog for receiving node %s", get_name());
     force_diag_update();
     last_message_received_ = now();
@@ -106,11 +107,9 @@ void Receiver::force_diag_update()
   diag_updater_->force_update();
 }
 
-void Receiver::diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void Receiver::diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat) const
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
-
-  is_timeout_ = (now() - last_message_received_).seconds() > timeout_;
 
   stat.add("Timeout", is_timeout_);
 

--- a/off_highway_general_purpose_radar/src/receiver.cpp
+++ b/off_highway_general_purpose_radar/src/receiver.cpp
@@ -228,7 +228,7 @@ void Receiver::manage_targets()
 
 void Receiver::publish_targets()
 {
-  if (pub_targets_->get_subscription_count() == 0) {
+  if (pub_targets_->get_subscription_count() == 0 || is_timeout_) {
     return;
   }
 
@@ -247,7 +247,7 @@ void Receiver::publish_targets()
 
 void Receiver::publish_pcl()
 {
-  if (pub_targets_pcl_->get_subscription_count() == 0) {
+  if (pub_targets_pcl_->get_subscription_count() == 0 || is_timeout_) {
     return;
   }
 

--- a/off_highway_radar/src/receiver.cpp
+++ b/off_highway_radar/src/receiver.cpp
@@ -222,7 +222,7 @@ void Receiver::manage_objects()
 
 void Receiver::publish_objects()
 {
-  if (pub_objects_->get_subscription_count() == 0) {
+  if (pub_objects_->get_subscription_count() == 0 || is_timeout_) {
     return;
   }
 
@@ -241,7 +241,7 @@ void Receiver::publish_objects()
 
 void Receiver::publish_pcl()
 {
-  if (pub_objects_pcl_->get_subscription_count() == 0) {
+  if (pub_objects_pcl_->get_subscription_count() == 0 || is_timeout_) {
     return;
   }
 

--- a/off_highway_uss/src/receiver.cpp
+++ b/off_highway_uss/src/receiver.cpp
@@ -271,7 +271,7 @@ void Receiver::manage_and_publish_objects()
 
 void Receiver::publish_objects()
 {
-  if (pub_objects_->get_subscription_count() == 0) {
+  if (pub_objects_->get_subscription_count() == 0 || is_timeout_) {
     return;
   }
 
@@ -290,7 +290,7 @@ void Receiver::publish_objects()
 
 void Receiver::publish_pcl()
 {
-  if (pub_objects_pcl_->get_subscription_count() == 0) {
+  if (pub_objects_pcl_->get_subscription_count() == 0 || is_timeout_) {
     return;
   }
 


### PR DESCRIPTION
By storing the check for timeout result, the publishers can easily check and decide not to publish. 
This way receiving nodes know about a timeout situation, similar to how Lidars do this.