### PR TITLE
ament_target_dependencies is deprecated for Kilted and Rolling

### DIFF
--- a/off_highway_can/CMakeLists.txt
+++ b/off_highway_can/CMakeLists.txt
@@ -33,7 +33,12 @@ add_library(${PROJECT_NAME} SHARED
   src/sender.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME} rclcpp can_msgs diagnostic_updater ros2_socketcan_msgs)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${can_msgs_TARGETS}
+  ${ros2_socketcan_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  rclcpp::rclcpp
+)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/off_highway_general_purpose_radar/CMakeLists.txt
+++ b/off_highway_general_purpose_radar/CMakeLists.txt
@@ -102,8 +102,7 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  ament_target_dependencies(test_pcl_point_target pcl_ros)
-  target_link_libraries(test_pcl_point_target ${PROJECT_NAME})
+  target_link_libraries(test_pcl_point_target ${PROJECT_NAME} pcl_ros::pcl_ros_tf)
 endif()
 
 ament_export_include_directories(

--- a/off_highway_premium_radar_sample/CMakeLists.txt
+++ b/off_highway_premium_radar_sample/CMakeLists.txt
@@ -31,21 +31,6 @@ find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
-set(dependencies
-  ASIO
-  diagnostic_updater
-  io_context
-  off_highway_premium_radar_sample_msgs
-  pcl_conversions
-  PCL
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  std_msgs
-  tf2
-  tf2_geometry_msgs
-)
-
 # Library
 add_library(${PROJECT_NAME} SHARED
   src/driver.cpp
@@ -56,11 +41,24 @@ add_library(${PROJECT_NAME} SHARED
   src/converters/default_converter.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME} SYSTEM ${dependencies})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${off_highway_premium_radar_sample_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  pcl_conversions::pcl_conversions
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  ${io_context_INCLUDE_DIRS}
 )
 
 install(
@@ -78,7 +76,20 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  ASIO
+  diagnostic_updater
+  io_context
+  off_highway_premium_radar_sample_msgs
+  pcl_conversions
+  PCL
+  rclcpp
+  rclcpp_components
+  sensor_msgs
+  std_msgs
+  tf2
+  tf2_geometry_msgs
+)
 
 # Executable
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/off_highway_radar/CMakeLists.txt
+++ b/off_highway_radar/CMakeLists.txt
@@ -24,17 +24,6 @@ find_package(off_highway_radar_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 
-set(dependencies
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  can_msgs
-  off_highway_can
-  off_highway_radar_msgs
-  pcl_conversions
-  PCL
-)
-
 # Library to be used in unit tests
 add_library(${PROJECT_NAME} SHARED
   src/receiver.cpp
@@ -45,7 +34,18 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(${PROJECT_NAME} SYSTEM ${dependencies})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${can_msgs_TARGETS}
+  ${off_highway_radar_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  off_highway_can::off_highway_can
+  pcl_conversions::pcl_conversions
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
+)
 
 install(
   DIRECTORY include/
@@ -61,7 +61,16 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  rclcpp
+  rclcpp_components
+  sensor_msgs
+  can_msgs
+  off_highway_can
+  off_highway_radar_msgs
+  pcl_conversions
+  PCL
+)
 
 # Receiver
 rclcpp_components_register_node(${PROJECT_NAME}
@@ -116,8 +125,7 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  ament_target_dependencies(test_pcl_point_object pcl_ros)
-  target_link_libraries(test_pcl_point_object ${PROJECT_NAME})
+  target_link_libraries(test_pcl_point_object ${PROJECT_NAME} pcl_ros::pcl_ros_tf)
 endif()
 
 ament_export_include_directories(

--- a/off_highway_uss/CMakeLists.txt
+++ b/off_highway_uss/CMakeLists.txt
@@ -24,17 +24,6 @@ find_package(off_highway_uss_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 
-set(dependencies
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  can_msgs
-  off_highway_can
-  off_highway_uss_msgs
-  pcl_conversions
-  PCL
-)
-
 # Library to be used in unit tests
 add_library(${PROJECT_NAME} SHARED
   src/interpolate_line.cpp
@@ -46,7 +35,18 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(${PROJECT_NAME} SYSTEM ${dependencies})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${can_msgs_TARGETS}
+  ${off_highway_uss_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  off_highway_can::off_highway_can
+  pcl_conversions::pcl_conversions
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
+)
 
 install(
   DIRECTORY include/
@@ -62,7 +62,16 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${dependencies})
+ament_export_dependencies(
+  rclcpp
+  rclcpp_components
+  sensor_msgs
+  can_msgs
+  off_highway_can
+  off_highway_uss_msgs
+  pcl_conversions
+  PCL
+)
 
 # Receiver
 rclcpp_components_register_node(${PROJECT_NAME}
@@ -132,8 +141,7 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  ament_target_dependencies(test_pcl_point_object pcl_ros)
-  target_link_libraries(test_pcl_point_object ${PROJECT_NAME})
+  target_link_libraries(test_pcl_point_object ${PROJECT_NAME} pcl_ros::pcl_ros_tf)
 endif()
 
 ament_package()


### PR DESCRIPTION
This syntax should work as of ROS 2 Foxy already

Easy migration as this comes from the deprecation messages in Kilted.