### PR TITLE
off_highway_can: split license element into two

### DIFF
--- a/off_highway_can/package.xml
+++ b/off_highway_can/package.xml
@@ -5,7 +5,8 @@
   <version>1.0.0</version>
   <description>The off_highway_can package</description>
   <maintainer email="robin.petereit@de.bosch.com">Robin Petereit</maintainer>
-  <license>Apache-2.0, MIT</license>
+  <license>Apache-2.0</license>
+  <license>MIT</license>
 
   <author email="robin.petereit@de.bosch.com">Robin Petereit</author>
   <author email="marcus.huenerbein@digital-workbench.de">Marcus Huenerbein</author>


### PR DESCRIPTION
Having two license strings into one element does give issues when generating the Yocto/OpenEmbedded bitbake recipes for meta-ros.

see: https://github.com/ros/meta-ros/commit/72dfb21b8f297d23e8c029edc04baadb17b1d24f

see:
  <license> (multiple, but at least one)

  Name of license for this package, e.g. BSD, GPL, LGPL.
  In order to assist machine readability, only include the license name in this tag.
  For multiple licenses multiple separate tags must be used.
  A package will have multiple licenses if different source files have different licenses.
  Every license occurring in the source files should have a corresponding <license> tag.
  For any explanatory text about licensing caveats, please use the <description> tag.

  -- https://ros.org/reps/rep-0149.html#license-multiple-but-at-least-one