### PR TITLE
Depend on ros_environment where needed (Humble version)

### DIFF
--- a/off_highway_general_purpose_radar/package.xml
+++ b/off_highway_general_purpose_radar/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 

--- a/off_highway_premium_radar_sample/package.xml
+++ b/off_highway_premium_radar_sample/package.xml
@@ -14,6 +14,7 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 

--- a/off_highway_radar/package.xml
+++ b/off_highway_radar/package.xml
@@ -14,6 +14,7 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 

--- a/off_highway_uss/package.xml
+++ b/off_highway_uss/package.xml
@@ -14,6 +14,7 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 


### PR DESCRIPTION
Recent commit f4e9860 ("Update dependency declarations for target_link_libraries", 2025-11-04) introduced dependency on ROS_DISTRO environment variable. Such an variable is only set if ros_environment package is available, but package.xml doesn't mention ros_environment as dependency.

This can lead to the following error when building the package without ros_environment (e.g. when using the Nix package manager):

    -- Found pcl_conversions: 2.4.5 (/.../ros-humble-pcl-conversions-2.4.5-r2/share/pcl_conversions/cmake)
    ...
    [ 50%] Building CXX object CMakeFiles/off_highway_general_purpose_radar.dir/src/receiver.cpp.o
    /build/off_highway_sensor_drivers-release-release-humble-off_highway_general_purpose_radar-0.10.0-1/src/receiver.cpp:20:10:
    fatal error: pcl_conversions/pcl_conversions.h: No such file or directory
       20 | #include "pcl_conversions/pcl_conversions.h"
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This commit adds dependency on ros_environment to packages where it is needed.