### PR TITLE
Fix pcl_conversions linking error in ROS buildfarm

### DIFF
--- a/off_highway_general_purpose_radar/CMakeLists.txt
+++ b/off_highway_general_purpose_radar/CMakeLists.txt
@@ -34,14 +34,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-# Get the ROS distribution name
-set(ROS_DISTRO $ENV{ROS_DISTRO})
-if(ROS_DISTRO STREQUAL "humble" OR ROS_DISTRO STREQUAL "jazzy")
-  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-    ${pcl_conversions_INCLUDE_DIRS}
-  )
-endif()
-
 target_link_libraries(off_highway_general_purpose_radar PUBLIC
       ${can_msgs_TARGETS}
       ${off_highway_general_purpose_radar_msgs_TARGETS}
@@ -53,9 +45,13 @@ target_link_libraries(off_highway_general_purpose_radar PUBLIC
       sensor_msgs::sensor_msgs_library
 )
 
-# Use pcl_conversions only if available (for ROS Rolling and LTS ROS distros later than Jazzy)
+# Link pcl_conversions - use modern target if available, otherwise fallback to variables
 if(TARGET pcl_conversions::pcl_conversions)
   target_link_libraries(${PROJECT_NAME} PUBLIC pcl_conversions::pcl_conversions)
+else()
+  # Fallback for ROS distributions where target doesn't exist (e.g., Jazzy)
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${pcl_conversions_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${pcl_conversions_LIBRARIES})
 endif()
 
 install(

--- a/off_highway_premium_radar_sample/CMakeLists.txt
+++ b/off_highway_premium_radar_sample/CMakeLists.txt
@@ -41,14 +41,6 @@ add_library(${PROJECT_NAME} SHARED
   src/converters/default_converter.cpp
 )
 
-# Get the ROS distribution name
-set(ROS_DISTRO $ENV{ROS_DISTRO})
-if(ROS_DISTRO STREQUAL "humble" OR ROS_DISTRO STREQUAL "jazzy")
-  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-    ${pcl_conversions_INCLUDE_DIRS}
-  )
-endif()
-
 target_link_libraries(${PROJECT_NAME} PUBLIC
   ${off_highway_premium_radar_sample_msgs_TARGETS}
   ${sensor_msgs_TARGETS}
@@ -64,9 +56,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   tf2_geometry_msgs::tf2_geometry_msgs
 )
 
-# Use pcl_conversions only if available (for ROS Rolling and LTS ROS distros later than Jazzy)
+# Link pcl_conversions - use modern target if available, otherwise fallback to variables
 if(TARGET pcl_conversions::pcl_conversions)
   target_link_libraries(${PROJECT_NAME} PUBLIC pcl_conversions::pcl_conversions)
+else()
+  # Fallback for ROS distributions where target doesn't exist (e.g., Jazzy)
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${pcl_conversions_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${pcl_conversions_LIBRARIES})
 endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/off_highway_radar/CMakeLists.txt
+++ b/off_highway_radar/CMakeLists.txt
@@ -35,14 +35,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-# Get the ROS distribution name
-set(ROS_DISTRO $ENV{ROS_DISTRO})
-if(ROS_DISTRO STREQUAL "humble" OR ROS_DISTRO STREQUAL "jazzy")
-  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-    ${pcl_conversions_INCLUDE_DIRS}
-  )
-endif()
-
 target_link_libraries(${PROJECT_NAME} PUBLIC
   ${can_msgs_TARGETS}
   ${off_highway_radar_msgs_TARGETS}
@@ -54,9 +46,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   sensor_msgs::sensor_msgs_library
 )
 
-# Use pcl_conversions only if available (for ROS Rolling and LTS ROS distros later than Jazzy)
+# Link pcl_conversions - use modern target if available, otherwise fallback to variables
 if(TARGET pcl_conversions::pcl_conversions)
   target_link_libraries(${PROJECT_NAME} PUBLIC pcl_conversions::pcl_conversions)
+else()
+  # Fallback for ROS distributions where target doesn't exist (e.g., Jazzy)
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${pcl_conversions_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${pcl_conversions_LIBRARIES})
 endif()
 
 install(

--- a/off_highway_uss/CMakeLists.txt
+++ b/off_highway_uss/CMakeLists.txt
@@ -36,14 +36,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-# Get the ROS distribution name
-set(ROS_DISTRO $ENV{ROS_DISTRO})
-if(ROS_DISTRO STREQUAL "humble" OR ROS_DISTRO STREQUAL "jazzy")
-  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-    ${pcl_conversions_INCLUDE_DIRS}
-  )
-endif()
-
 target_link_libraries(${PROJECT_NAME} PUBLIC
   ${can_msgs_TARGETS}
   ${off_highway_uss_msgs_TARGETS}
@@ -55,9 +47,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   sensor_msgs::sensor_msgs_library
 )
 
-# Use pcl_conversions only if available (for ROS Rolling and LTS ROS distros later than Jazzy)
+# Link pcl_conversions - use modern target if available, otherwise fallback to variables
 if(TARGET pcl_conversions::pcl_conversions)
   target_link_libraries(${PROJECT_NAME} PUBLIC pcl_conversions::pcl_conversions)
+else()
+  # Fallback for ROS distributions where target doesn't exist (e.g., Jazzy)
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${pcl_conversions_INCLUDE_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC ${pcl_conversions_LIBRARIES})
 endif()
 
 install(


### PR DESCRIPTION
There's currently a [regression in Jazzy regarding this repo](https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSIONhttps://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION). 

Multiple packages fail to build in the ROS buildfarm and they seem to be failing with:
```                                                                                                                                                 
fatal error: pcl_conversions/pcl_conversions.h: No such file or directory                                                                                                                                          
```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
  
  The build might have worked locally but fails on the buildfarm because `CMakeLists.txt` files on those packages rely on the `$ROS_DISTRO` environment variable to add include directories, but the ROS buildfarm does not set `$ROS_DISTRO` during Debian package builds by default (see [this Stack Exchange post](https://robotics.stackexchange.com/questions/84189/buildfarm-doesnt-define-the-ros-distro-environment-variable)).                                                                       
                                                                                                                                                                                                                                                                                                                                                                         
  This PR removes dependency on the `$ROS_DISTRO` environment variable and instead check directly for target existence.                                                                                                                                                                                           
                                                                                                                                                                                                                     
  
 Due to the upcoming [Jazzy patch sync](https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2026-01-22/) and to avoid removal or downgrade of the package I'm suggesting this quick fix. Please consider including it and releasing the packages to `jazzy` ASAP so it can be included in the [upcoming sync](https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2026-01-22/).
 
 Thanks!