### PR TITLE
Revert "Depend on ros_environment where needed (Jazzy version)"

### DIFF
--- a/off_highway_general_purpose_radar/package.xml
+++ b/off_highway_general_purpose_radar/package.xml
@@ -13,7 +13,6 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
-  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 

--- a/off_highway_premium_radar_sample/package.xml
+++ b/off_highway_premium_radar_sample/package.xml
@@ -14,7 +14,6 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
-  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 

--- a/off_highway_radar/package.xml
+++ b/off_highway_radar/package.xml
@@ -14,7 +14,6 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
-  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 

--- a/off_highway_uss/package.xml
+++ b/off_highway_uss/package.xml
@@ -14,7 +14,6 @@
 
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
-  <build_depend>ros_environment</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>
 


### PR DESCRIPTION
Depending on the `ROS_ENVIRONMENT`  breaks the build on the ROS buildfarm therefore I suggested: https://github.com/bosch-engineering/off_highway_sensor_drivers/pull/30, because that approach removes the use of `ROS_ENVIRONMENT` this is not needed anymore:

Reverts bosch-engineering/off_highway_sensor_drivers#28